### PR TITLE
Disable tuvok for the time being

### DIFF
--- a/toolbox/bin/lint.sh
+++ b/toolbox/bin/lint.sh
@@ -4,4 +4,6 @@ set -eu
 . $(dirname $(realpath $0))/variables.sh
 
 terraform fmt -check -diff
-tuvok . || exit 0 # don't fail builds yet
+
+# temporarily disabled
+# tuvok . || exit 0 # don't fail builds yet


### PR DESCRIPTION
Temporarily disable tuvok, while we work through two issues:
- it's slow on large directory trees
- we should consider linting only changed files