### PR TITLE
Renable tuvok

### DIFF
--- a/toolbox/Dockerfile
+++ b/toolbox/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3-alpine
 
 # versions to install
 ARG JSON2HCL_VERSION=0.0.6
-ARG TUVOK_VERSION=v0.0.3
+ARG TUVOK_VERSION=v0.0.4
 
 # pre-reqs for toolbox & tuvok
 RUN apk --update add bash git openssh openssl curl wget py-pip jq

--- a/toolbox/bin/lint.sh
+++ b/toolbox/bin/lint.sh
@@ -4,6 +4,4 @@ set -eu
 . $(dirname $(realpath $0))/variables.sh
 
 terraform fmt -check -diff
-
-# temporarily disabled
-# tuvok . || exit 0 # don't fail builds yet
+tuvok . || exit 0 # don't fail builds yet


### PR DESCRIPTION
We disabled tuvok in https://github.com/rackspace-infrastructure-automation/rackspace-toolbox/pull/22. This re-enables it, and it runs faster now.