### PR TITLE
Allow apply of deleted layer as well

### DIFF
--- a/toolbox/bin/apply.sh
+++ b/toolbox/bin/apply.sh
@@ -21,6 +21,12 @@ for LAYER in $CHANGED_LAYERS; do
   ls -la "$WORKSPACE_DIR/.terraform.$LAYER.tar.gz"
   ls -la "$WORKSPACE_DIR/terraform.$LAYER.plan"
 
+  # ensure even deleted layer can be applied (no-op)
+  if [ ! -d "$LAYERS_DIR/$LAYER" ]; then
+    echo "> Layer directory $LAYERS_DIR/$LAYER was not found, creating an empty version."
+    mkdir -p "$LAYERS_DIR/$LAYER"
+  fi
+
   # uncache .terraform for the apply
   (cd "$LAYERS_DIR/$LAYER" && tar xzf "$WORKSPACE_DIR/.terraform.$LAYER.tar.gz")
 


### PR DESCRIPTION
#28 succeeded on fixing the plan step, so it no longer errors out when a plan is run on a deleted layer. This fixes the same for the apply step.

The fix is slightly different here in that we only needed a directory to exist, and we'll untar the previous content from the plan step.