### PR TITLE
touches full_plan_output.log to avoid breaking builds that include it…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rackspace-toolbox Changelog
 
+## [1.7.2](https://github.com/rackspace-infrastructure-automation/rackspace-toolbox/releases/tag/1.7.2) (Jan 29, 2019)
+
+Touches full_plan_output.log to avoid breaking builds that include it in persist_to_workspace.
+
 ## [1.7.1](https://github.com/rackspace-infrastructure-automation/rackspace-toolbox/releases/tag/1.7.1) (Jan 29, 2019)
 
 Writes some artifacts even if there is nothing to plan. Also, prints toolbox version at beginning of scripts.

--- a/toolbox/bin/plan.sh
+++ b/toolbox/bin/plan.sh
@@ -3,6 +3,9 @@ set -eu -o pipefail
 
 source $(dirname $(realpath $0))/variables.sh
 
+# this is done for backward compatibility to builds that are specifically including full_plan_output.log in persist_to_workspace
+touch "$WORKSPACE_DIR/full_plan_output.log"
+
 mkdir -p /tmp/artifacts/
 ALL_OUTPUT="/tmp/artifacts/terraform_all_outputs.log"
 

--- a/toolbox/bin/variables.sh
+++ b/toolbox/bin/variables.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu -o pipefail
 
-echo "Rackspace Toolbox - 1.7.1"
+echo "Rackspace Toolbox - 1.7.2"
 
 check_old() {
   local fake_hostname='github.com.original.invalid'


### PR DESCRIPTION
… in persist_to_workspace