### PR TITLE
Add newer versions of Terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rackspace-toolbox Changelog
 
+## [1.7.5](https://github.com/rackspace-infrastructure-automation/rackspace-toolbox/releases/tag/1.7.5) (Mar 12, 2019)
+
+Updated to pre-install the most recent stable releases of terraform.
+
 ## [1.7.4](https://github.com/rackspace-infrastructure-automation/rackspace-toolbox/releases/tag/1.7.4) (Mar 11, 2019)
 
 Ensures both plan and apply succeed when working with deleted layer directories.

--- a/toolbox/Dockerfile
+++ b/toolbox/Dockerfile
@@ -17,6 +17,9 @@ RUN chmod +x /usr/local/bin/json2hcl
 RUN pip install git+https://github.com/rackerlabs/tuvok.git@$TUVOK_VERSION
 
 # recent terraform versions
+RUN tfenv install 0.11.13
+RUN tfenv install 0.11.12
+RUN tfenv install 0.11.11
 RUN tfenv install 0.11.10
 RUN tfenv install 0.11.9
 RUN tfenv install 0.11.8

--- a/toolbox/Dockerfile
+++ b/toolbox/Dockerfile
@@ -18,10 +18,7 @@ RUN pip install git+https://github.com/rackerlabs/tuvok.git@$TUVOK_VERSION
 
 # recent terraform versions
 RUN tfenv install 0.11.13
-RUN tfenv install 0.11.12
 RUN tfenv install 0.11.11
-RUN tfenv install 0.11.10
-RUN tfenv install 0.11.9
 RUN tfenv install 0.11.8
 RUN tfenv install 0.11.7
 RUN tfenv install 0.11.4

--- a/toolbox/bin/variables.sh
+++ b/toolbox/bin/variables.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu -o pipefail
 
-echo "Rackspace Toolbox - 1.7.4"
+echo "Rackspace Toolbox - 1.7.5"
 
 check_old() {
   local fake_hostname='github.com.original.invalid'


### PR DESCRIPTION
The toolbox will gracefully download and install other versions if a consumer uses one that is not included. However, pre-installing them speeds up build times by avoiding having to download and install them on the fly. This change updates the toolbox to pre-install the most recent stable releases.