### PR TITLE
Update tuvok and preinstall Terraform 0.12.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # rackspace-toolbox Changelog
 
+## [1.7.7](https://github.com/rackspace-infrastructure-automation/rackspace-toolbox/releases/tag/1.7.7) (Feb 6, 2020)
+
+Update to pre-install several stable releases of terraform v0.12.x.
+Update to latest release of tuvok.
+
 ## [1.7.6](https://github.com/rackspace-infrastructure-automation/rackspace-toolbox/releases/tag/1.7.6) (Oct 23, 2019)
 
 Output state bucket to artifacts.

--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -159,7 +159,7 @@ No changes. Infrastructure is up-to-date.")
   plan.sh
 
   diff /tmp/artifacts/terraform_all_outputs.log <(echo \
-"Rackspace Toolbox - 1.7.6
+"Rackspace Toolbox - 1.7.7
 Modules found:
 shared_code
 Using bucket for state backend: le-bucket in le-region

--- a/toolbox/Dockerfile
+++ b/toolbox/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:3-alpine
 
 # versions to install
-ARG JSON2HCL_VERSION=0.0.6
-ARG TUVOK_VERSION=v0.0.4
+ARG TUVOK_VERSION=v0.1.3
 
 # pre-reqs for toolbox & tuvok
 RUN apk --update add bash git openssh openssl curl wget py-pip jq
@@ -11,12 +10,12 @@ RUN wget https://github.com/rackspace-infrastructure-automation/tfenv/archive/v0
   && ln -s /var/opt/tfenv-0.6.0/bin/* /usr/local/bin
 RUN pip install --upgrade pip && pip install --progress-bar=off awscli
 
-# tuvok and json2hcl, then run tuvok once to be sure it loads correctly
-ADD https://github.com/kvz/json2hcl/releases/download/v${JSON2HCL_VERSION}/json2hcl_v${JSON2HCL_VERSION}_linux_amd64 /usr/local/bin/json2hcl
-RUN chmod +x /usr/local/bin/json2hcl
+# install tuvok
 RUN pip install git+https://github.com/rackerlabs/tuvok.git@$TUVOK_VERSION
 
 # recent terraform versions
+RUN tfenv install 0.12.20
+RUN tfenv install 0.12.17
 RUN tfenv install 0.11.13
 RUN tfenv install 0.11.11
 RUN tfenv install 0.11.8

--- a/toolbox/bin/variables.sh
+++ b/toolbox/bin/variables.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 mkdir -p /tmp/artifacts/
 ALL_OUTPUT="/tmp/artifacts/terraform_all_outputs.log"
 
-echo "Rackspace Toolbox - 1.7.6" | tee -a "$ALL_OUTPUT"
+echo "Rackspace Toolbox - 1.7.7" | tee -a "$ALL_OUTPUT"
 
 check_old() {
   local fake_hostname='github.com.original.invalid'


### PR DESCRIPTION
Changes add more features related to the use of terraform 0.12.x within customer environments.  Changes include:
- Preinstall terraform 0.12.17, the primary version used for Rackspace terraform module development
- Preinstall terraform 0.12.20, the latest terraform version at the time of this PR
- Updates the installed tuvok version to 0.1.3, adding support for HCL2 and removing the need for the json2hcl utility