### PR TITLE
ensure key file is in pem format

### DIFF
--- a/toolbox/bin/pull-aws-creds.sh
+++ b/toolbox/bin/pull-aws-creds.sh
@@ -22,6 +22,10 @@ if [ ! -r "$KEY_FILE" ]; then
 fi
 
 set -o pipefail
+
+echo >&2 "> Found key file: $KEY_FILE, ensuring it is in PEM format"
+ssh-keygen -p -N '' -m pem -f $KEY_FILE
+
 FINGERPRINT=$(ssh-keygen -E md5 -lf "$KEY_FILE" | cut -f2 -d' ')
 REPO_NAME=${REPO_NAME:-$(git config --get remote.origin.url | sed -e 's/^git@github[.]com://' -e 's/^[^\/]*\///' -e 's/[.]git$//')}
 TIME=$(date +%s)


### PR DESCRIPTION
New deploy keys are in OpenSSH format. We need it to be in PEM format for signing here: https://github.com/rackspace-infrastructure-automation/rackspace-toolbox/blob/master/toolbox/bin/pull-aws-creds.sh#L32